### PR TITLE
Add GitHub Actions workflow for PHP tests

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,0 +1,47 @@
+name: PHP Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+
+    name: PHP ${{ matrix.php-version }} Tests
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        extensions: pdo, sqlite
+        coverage: xdebug
+        tools: composer:v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ matrix.php-version }}-
+
+    - name: Install dependencies
+      run: |
+        composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow to run tests across PHP versions 7.4 to 8.4
- Workflow runs on push to main and on PRs targeting main branch
- Includes caching of composer dependencies for faster builds

## Test plan
- Check that workflow triggers correctly on PR
- Verify tests run on all configured PHP versions

🤖 Generated with [Claude Code](https://claude.ai/code)