### PR TITLE
Fix PHPUnit tests by updating path filtering in DebugBacktrace

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,0 +1,47 @@
+name: PHP Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+
+    name: PHP ${{ matrix.php-version }} Tests
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        extensions: pdo, sqlite
+        coverage: xdebug
+        tools: composer:v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ hashFiles('**/composer.json') }}
+        restore-keys: |
+          ${{ runner.os }}-php-${{ matrix.php-version }}-
+
+    - name: Install dependencies
+      run: |
+        composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: vendor/bin/phpunit

--- a/src/Debug/DebugBacktrace.php
+++ b/src/Debug/DebugBacktrace.php
@@ -12,7 +12,7 @@ class DebugBacktrace
         $trace = array_values(array_filter($trace, function($item) {
             $file = $item['file'] ?? '';
             return !empty($file) 
-                && strpos($file, '/php-pdo-logger/src') === false
+                && strpos($file, '/PowerPdo/src') === false
                 && strpos($file, 'vendor/phpunit') === false;
         }));
 


### PR DESCRIPTION
## Summary
- Fixed failing PHPUnit tests by updating the path filter in DebugBacktrace class
- Changed path filter from '/php-pdo-logger/src' to '/PowerPdo/src' to match the new namespace
- All tests now pass successfully

## Test plan
- Verified that all PHPUnit tests pass with the fix
- This fix will also ensure GitHub Actions workflow runs correctly

🤖 Generated with [Claude Code](https://claude.ai/code)